### PR TITLE
Rename admin_token secret to tb_admin_token

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,7 @@
 # Iterating your Tinybird data projects with a GitHub repository
 
 Please, follow the [`Working with git`](https://www.tinybird.co/docs/guides/working-with-git.html) guide. It will setup automatically your GitHub workflow for iterating your Tinybird data project.
-A new secret key `ADMIN_TOKEN` will be needed in your repository.
+A new secret key `TB_ADMIN_TOKEN` will be needed in your repository.
 
 > Visit `Settings >> Secrets and variables >> Actions` section and create a "New repository secret" 
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Set environment variables
         run: |
@@ -122,7 +122,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -154,7 +154,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -187,7 +187,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -219,7 +219,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -154,7 +154,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -187,7 +187,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -219,7 +219,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Set environment variables
         run: |
@@ -122,7 +122,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -154,7 +154,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -187,7 +187,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -219,7 +219,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: .
     secrets:
-      admin_token:
+      tb_admin_token:
         required: true
       tb_host:
         required: true
@@ -39,7 +39,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.admin_token }}" ]] || { echo "Set ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
 
       - name: Set environment variables
         run: |
@@ -62,7 +62,7 @@ jobs:
         run: |
             tb \
               --host ${{ secrets.tb_host }}  \
-              --token ${{ secrets.admin_token }}  \
+              --token ${{ secrets.tb_admin_token }}  \
               env create tmp_cd_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
               ${_ENV_FLAGS}
 
@@ -91,7 +91,7 @@ jobs:
             else
               tb auth \
                   --host ${{ secrets.tb_host }} \
-                  --token ${{ secrets.admin_token }}
+                  --token ${{ secrets.tb_admin_token }}
               CD_DEPLOY_FILE=./deploy/${VERSION}/cd-deploy.sh
               if [ ! -f "$CD_DEPLOY_FILE" ]; then
                 tb deploy
@@ -122,7 +122,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.admin_token }}" ]] || { echo "Set ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -134,7 +134,7 @@ jobs:
         run: |
           tb \
           --host ${{ secrets.tb_host }} \
-          --token ${{ secrets.admin_token }} \
+          --token ${{ secrets.tb_admin_token }} \
           env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
           --yes
 
@@ -154,7 +154,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.admin_token }}" ]] || { echo "Set ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -167,7 +167,7 @@ jobs:
           source .tinyenv
           tb \
           --host ${{ secrets.tb_host }} \
-          --token ${{ secrets.admin_token }} \
+          --token ${{ secrets.tb_admin_token }} \
           release promote \
           --semver $VERSION
 
@@ -187,7 +187,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.admin_token }}" ]] || { echo "Set ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -200,7 +200,7 @@ jobs:
           source .tinyenv
           tb \
           --host ${{ secrets.tb_host }} \
-          --token ${{ secrets.admin_token }} \
+          --token ${{ secrets.tb_admin_token }} \
           release rollback
 
   release_rm:
@@ -219,7 +219,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.admin_token }}" ]] || { echo "Set ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -232,6 +232,6 @@ jobs:
           source .tinyenv
           tb \
           --host ${{ secrets.tb_host }} \
-          --token ${{ secrets.admin_token }} \
+          --token ${{ secrets.tb_admin_token }} \
           release rm \
           --semver $VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Set environment variables
         run: |
@@ -114,7 +114,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: .
     secrets:
-      admin_token:
+      tb_admin_token:
         required: true
       tb_host:
         required: true
@@ -33,7 +33,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.admin_token }}" ]] || { echo "Set ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
 
       - name: Set environment variables
         run: |
@@ -55,7 +55,7 @@ jobs:
         run: |
           tb \
           --host ${{ secrets.tb_host }} \
-          --token ${{ secrets.admin_token }} \
+          --token ${{ secrets.tb_admin_token }} \
           env create tmp_ci_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
           ${_ENV_FLAGS}
 
@@ -114,7 +114,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.admin_token }}" ]] || { echo "Set ADMIN_TOKEN variable"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Set TB_ADMIN_TOKEN variable"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -126,6 +126,6 @@ jobs:
         run: |
           tb \
           --host ${{ secrets.tb_host }} \
-          --token ${{ secrets.admin_token }} \
+          --token ${{ secrets.tb_admin_token }} \
           env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
           --yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Set environment variables
         run: |
@@ -114,7 +114,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Set environment variables
         run: |
@@ -114,7 +114,7 @@ jobs:
 
       - name: Validate input
         run: |
-          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to ${{ secrets.tb_host }}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
+          [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli

--- a/.gitlab/README.md
+++ b/.gitlab/README.md
@@ -1,7 +1,7 @@
 # Iterating your Tinybird data projects with a GitLab repository
 
 Please, follow the [`Working with git`](https://www.tinybird.co/docs/guides/working-with-git.html) guide. It will setup automatically your GitLab CI for iterating your Tinybird data project.
-A new ENV variable `ADMIN_TOKEN` will be needed in your repository.
+A new ENV variable `TB_ADMIN_TOKEN` will be needed in your repository.
 
 > Visit `Settings >> CI/CD >> Variables` section, and "Add variable" 
 

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -14,7 +14,7 @@ variables:
 .validate_input: &validate_input
   - |
     if [[ $TB_ADMIN_TOKEN =~ .*TB_ADMIN_TOKEN ]]; then
-      echo "Set TB_ADMIN_TOKEN variable"; exit 1;
+      echo "Go to ${TB_HOST}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1;
     fi
 
 .run_ci:

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -14,7 +14,7 @@ variables:
 .validate_input: &validate_input
   - |
     if [[ $TB_ADMIN_TOKEN =~ .*TB_ADMIN_TOKEN ]]; then
-      echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1;
+      echo "Go to the tokens section in your Workspace, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1;
     fi
 
 .run_ci:

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -14,7 +14,7 @@ variables:
 .validate_input: &validate_input
   - |
     if [[ $TB_ADMIN_TOKEN =~ .*TB_ADMIN_TOKEN ]]; then
-      echo "Go to ${TB_HOST}/tokens, copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1;
+      echo "Go the tokens section in your workspace and copy the "admin token (user@domain.com)" associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1;
     fi
 
 .run_ci:

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -13,8 +13,8 @@ variables:
 
 .validate_input: &validate_input
   - |
-    if [[ $ADMIN_TOKEN =~ .*ADMIN_TOKEN ]]; then
-      echo "Set ADMIN_TOKEN variable"; exit 1;
+    if [[ $TB_ADMIN_TOKEN =~ .*TB_ADMIN_TOKEN ]]; then
+      echo "Set TB_ADMIN_TOKEN variable"; exit 1;
     fi
 
 .run_ci:
@@ -47,7 +47,7 @@ variables:
     - |
       tb \
         --host $TB_HOST \
-        --token $ADMIN_TOKEN \
+        --token $TB_ADMIN_TOKEN \
         env create tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
         ${_ENV_FLAGS}
 
@@ -110,7 +110,7 @@ variables:
     - |
       tb \
         --host $TB_HOST \
-        --token $ADMIN_TOKEN \
+        --token $TB_ADMIN_TOKEN \
         env create tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
         ${_ENV_FLAGS}
 
@@ -139,7 +139,7 @@ variables:
         if [ ! -f "$CD_DEPLOY_FILE" ]; then
           tb auth \
             --host $TB_HOST \
-            --token $ADMIN_TOKEN
+            --token $TB_ADMIN_TOKEN
           tb deploy
         fi
       fi
@@ -173,7 +173,7 @@ variables:
     - |
       tb \
       --host $TB_HOST \
-      --token $ADMIN_TOKEN \
+      --token $TB_ADMIN_TOKEN \
       env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
       --yes
 
@@ -199,7 +199,7 @@ variables:
     - |
       tb \
       --host $TB_HOST \
-      --token $ADMIN_TOKEN \
+      --token $TB_ADMIN_TOKEN \
       env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
       --yes
 
@@ -224,7 +224,7 @@ variables:
       source .tinyenv
       tb \
       --host $TB_HOST \
-      --token $ADMIN_TOKEN \
+      --token $TB_ADMIN_TOKEN \
       release promote \
       --semver $VERSION
 
@@ -249,7 +249,7 @@ variables:
       source .tinyenv
       tb \
       --host $TB_HOST \
-      --token $ADMIN_TOKEN \
+      --token $TB_ADMIN_TOKEN \
       release rollback
 
 .release_rm:
@@ -273,5 +273,5 @@ variables:
       source .tinyenv
       tb \
       --host $TB_HOST \
-      --token $ADMIN_TOKEN \
+      --token $TB_ADMIN_TOKEN \
       release rm --semver $VERSION


### PR DESCRIPTION
Renames all `admin_token` secrets to `tb_admin_token` to have all our secrets _namespaced_ into the `tb_` prefix.

This is a breaking change, so we need to bump the next release version to `v2.0.0`.