### PR TITLE
not clean environment after ci and more

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
           source .tinyenv
           echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
           echo "_ENV_FLAGS=$_ENV_FLAGS" >> $GITHUB_ENV
+          echo "_NORMALIZED_ENV_NAME=$_NORMALIZED_ENV_NAME" >> $GITHUB_ENV
 
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
@@ -67,7 +68,7 @@ jobs:
             tb \
               --host ${{ secrets.tb_host }}  \
               --token ${{ secrets.tb_admin_token }}  \
-              env create tmp_cd_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
+              env create tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
               ${_ENV_FLAGS}
 
       - name: List changes with Workspace (should be empty)
@@ -139,7 +140,7 @@ jobs:
           tb \
           --host ${{ secrets.tb_host }} \
           --token ${{ secrets.tb_admin_token }} \
-          env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
+          env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
           --yes
 
   release_promote:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,7 @@ jobs:
             tb \
               --host ${{ secrets.tb_host }}  \
               --token ${{ secrets.tb_admin_token }}  \
-              env create tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
+              env create tmp_cd_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
               ${_ENV_FLAGS}
 
       - name: List changes with Workspace (should be empty)
@@ -140,7 +140,7 @@ jobs:
           tb \
           --host ${{ secrets.tb_host }} \
           --token ${{ secrets.tb_admin_token }} \
-          env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
+          env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
           --yes
 
   release_promote:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,12 @@ jobs:
           echo "_NORMALIZED_ENV_NAME=$_NORMALIZED_ENV_NAME" >> $GITHUB_ENV
 
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
 
       - name: Tinybird version
         run: tb --version
@@ -130,7 +135,12 @@ jobs:
           [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the 'admin token (user@domain.com)' associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
 
       - name: Tinybird version
         run: tb --version       
@@ -162,7 +172,12 @@ jobs:
           [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the 'admin token (user@domain.com)' associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
 
       - name: Tinybird version
         run: tb --version
@@ -195,7 +210,12 @@ jobs:
           [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the 'admin token (user@domain.com)' associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
 
       - name: Tinybird version
         run: tb --version
@@ -227,7 +247,12 @@ jobs:
           [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the 'admin token (user@domain.com)' associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
 
       - name: Tinybird version
         run: tb --version

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Deploy changes to the main Workspace
         run: |
             source .tinyenv
-            if ${{ inputs.tb_deploy}}; then      
+            if ${{ inputs.tb_deploy }}; then
               tb env deploy --semver ${VERSION} --wait
               tb release ls
             else
@@ -144,7 +144,7 @@ jobs:
           --yes
 
   release_promote:
-    if: ${{ inputs.tb_deploy}}
+    if: ${{ inputs.tb_deploy && github.event.workflow_dispatch }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -177,7 +177,7 @@ jobs:
           --semver $VERSION
 
   release_rollback:
-    if: ${{ inputs.tb_deploy}}
+    if: ${{ inputs.tb_deploy && github.event.workflow_dispatch }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -209,7 +209,7 @@ jobs:
           release rollback
 
   release_rm:
-    if: ${{ inputs.tb_deploy}}
+    if: ${{ inputs.tb_deploy && github.event.workflow_dispatch }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.data_project_dir }}
+    if: ${{ github.event.action != 'closed' }}
     steps:
       - uses: actions/checkout@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Try delete previous Environment
         run: |
-          output=$(tb env ls)
+          output=$(tb --host ${{ secrets.tb_host }} --token ${{ secrets.tb_admin_token }} env ls)
           ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }}"
 
           # Check if the environment name exists in the output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
         required: false
         type: string
         default: .
+      cleanup:
+        description: "set to true to clean up the CI Environment after the ci_branching job, otherwise the CI Environment is left to debug any possible issue"
+        required: false
+        type: boolean
+        default: false
     secrets:
       tb_admin_token:
         required: true
@@ -43,6 +48,7 @@ jobs:
           source .tinyenv
           echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
           echo "_ENV_FLAGS=$_ENV_FLAGS" >> $GITHUB_ENV
+          echo "_NORMALIZED_ENV_NAME=$_NORMALIZED_ENV_NAME" >> $GITHUB_ENV
       - name: Install Tinybird CLI
         run: pip install tinybird-cli
 
@@ -55,12 +61,28 @@ jobs:
       - name: Check auth
         run: tb --host ${{ secrets.tb_host }} --token ${{ secrets.tb_admin_token }} auth info
 
+      - name: Try delete previous Environment
+        run: |
+          output=$(tb env ls)
+          ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }}"
+
+          # Check if the environment name exists in the output
+          if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
+              tb \
+                --host ${{ vars.TB_HOST }} \
+                --token ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }} \
+                env rm $ENVIRONMENT_NAME \
+                --yes
+          else
+              echo "Skipping clean up: The Environment '$ENVIRONMENT_NAME' does not exist."
+          fi
+
       - name: Create new test Environment with data
         run: |
           tb \
           --host ${{ secrets.tb_host }} \
           --token ${{ secrets.tb_admin_token }} \
-          env create tmp_ci_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
+          env create tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
           ${_ENV_FLAGS}
 
       - name: List changes with Main Environment
@@ -107,7 +129,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.data_project_dir }}
-    if: ${{ always() }}
+    if: ${{ inputs.cleanup}}
     needs: [ci_branching]
     steps:
       - uses: actions/checkout@master
@@ -131,5 +153,5 @@ jobs:
           tb \
           --host ${{ secrets.tb_host }} \
           --token ${{ secrets.tb_admin_token }} \
-          env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${GITHUB_RUN_ID} \
+          env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
           --yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }}"
 
           # Check if the environment name exists in the output
-          if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
+          if echo "$output" | grep -q "\b$ENVIRONMENT_NAME\b"; then
               tb \
                 --host ${{ secrets.tb_host }} \
                 --token ${{ secrets.tb_admin_token }} \
@@ -161,7 +161,7 @@ jobs:
           ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }}"
 
           # Check if the environment name exists in the output
-          if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
+          if echo "$output" | grep -q "\b$ENVIRONMENT_NAME\b"; then
               tb \
                 --host ${{ secrets.tb_host }} \
                 --token ${{ secrets.tb_admin_token }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ on:
         required: true
       tb_host:
         required: true
+  pull_request:
+    branches:
+      - main
+      - master
+    types: [opened, reopened, labeled, unlabeled, synchronize, closed]
 
 jobs:
   ci_branching:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: Run pipe regression tests
         run: |
+          source .tinyenv
           echo ${{ steps.regression_labels.outputs.labels }}
           REGRESSION_LABELS=$(echo "${{ steps.regression_labels.outputs.labels }}" | awk -F, '{for (i=1; i<=NF; i++) if ($i ~ /^--/) print $i}' ORS=',' | sed 's/,$//')
           echo ${REGRESSION_LABELS}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,6 @@ on:
         required: false
         type: string
         default: .
-      cleanup:
-        description: "set to true to clean up the CI Environment after the ci_branching job, otherwise the CI Environment is left to debug any possible issue"
-        required: false
-        type: boolean
-        default: false
     secrets:
       tb_admin_token:
         required: true
@@ -130,8 +125,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.data_project_dir }}
-    if: ${{ inputs.cleanup}}
-    needs: [ci_branching]
+    if: ${{ github.event.action == 'closed' }}
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v3
@@ -149,10 +143,18 @@ jobs:
       - name: Tinybird version
         run: tb --version       
 
-      - name: Drop test Environment
+      - name: Try delete previous Environment
         run: |
-          tb \
-          --host ${{ secrets.tb_host }} \
-          --token ${{ secrets.tb_admin_token }} \
-          env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
-          --yes
+          output=$(tb --host ${{ secrets.tb_host }} --token ${{ secrets.tb_admin_token }} env ls)
+          ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }}"
+
+          # Check if the environment name exists in the output
+          if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
+              tb \
+                --host ${{ secrets.tb_host }} \
+                --token ${{ secrets.tb_admin_token }} \
+                env rm $ENVIRONMENT_NAME \
+                --yes
+          else
+              echo "Skipping clean up: The Environment '$ENVIRONMENT_NAME' does not exist."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ on:
         required: true
       tb_host:
         required: true
-  pull_request:
-    branches:
-      - main
-      - master
-    types: [opened, reopened, labeled, unlabeled, synchronize, closed]
 
 jobs:
   ci_branching:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           echo "_ENV_FLAGS=$_ENV_FLAGS" >> $GITHUB_ENV
           echo "_NORMALIZED_ENV_NAME=$_NORMALIZED_ENV_NAME" >> $GITHUB_ENV
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli
+        run: pip install tinybird-cli==1.0.1.dev1
 
       - name: Tinybird version
         run: tb --version       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
           # Check if the environment name exists in the output
           if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
               tb \
-                --host ${{ vars.TB_HOST }} \
-                --token ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }} \
+                --host ${{ secrets.tb_host }} \
+                --token ${{ secrets.tb_admin_token }} \
                 env rm $ENVIRONMENT_NAME \
                 --yes
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,14 @@ jobs:
           echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
           echo "_ENV_FLAGS=$_ENV_FLAGS" >> $GITHUB_ENV
           echo "_NORMALIZED_ENV_NAME=$_NORMALIZED_ENV_NAME" >> $GITHUB_ENV
+
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli==1.0.1.dev1
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
 
       - name: Tinybird version
         run: tb --version       
@@ -139,7 +145,12 @@ jobs:
           [[ "${{ secrets.tb_admin_token }}" ]] || { echo "Go to the tokens section in your Workspace, copy the 'admin token (user@domain.com)' associated to a user account and set TB_ADMIN_TOKEN as a Secret in your Git repository"; exit 1; }
 
       - name: Install Tinybird CLI
-        run: pip install tinybird-cli
+        run: |
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install tinybird-cli
+          fi
 
       - name: Tinybird version
         run: tb --version       

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -49,7 +49,7 @@ variables:
     - tb check
 
     # Check auth
-    tb --host $TB_HOST --token $TB_ADMIN_TOKEN auth info
+    - tb --host $TB_HOST --token $TB_ADMIN_TOKEN auth info
 
     # Try delete previous Environment
     - |

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -48,7 +48,7 @@ variables:
 
     # Try delete previous Environment
     - |
-      output=$(tb env ls)
+      output=$(tb --host $TB_HOST --token $TB_ADMIN_TOKEN env ls)
       ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH}"
 
       # Check if the environment name exists in the output

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -54,7 +54,7 @@ variables:
     # Try delete previous Environment
     - |
       output=$(tb --host $TB_HOST --token $TB_ADMIN_TOKEN env ls)
-      ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH}"
+      ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_MERGE_REQUEST_IID}"
 
       # Check if the environment name exists in the output
       if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
@@ -72,7 +72,7 @@ variables:
       tb \
         --host $TB_HOST \
         --token $TB_ADMIN_TOKEN \
-        env create tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
+        env create tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_MERGE_REQUEST_IID} \
         ${_ENV_FLAGS}
 
     # List changes with Main Environment
@@ -208,7 +208,7 @@ variables:
       tb \
       --host $TB_HOST \
       --token $TB_ADMIN_TOKEN \
-      env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
+      env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_MERGE_REQUEST_IID} \
       --yes
 
 .cleanup_cd_branch:

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -54,8 +54,8 @@ variables:
       # Check if the environment name exists in the output
       if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
           tb \
-            --host ${{ vars.TB_HOST }} \
-            --token ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }} \
+            --host $TB_HOST \
+            --token $TB_ADMIN_TOKEN \
             env rm $ENVIRONMENT_NAME \
             --yes
       else

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -35,7 +35,12 @@ variables:
     - source .venv/bin/activate
 
     # Install Tinybird CLI
-    - pip install tinybird-cli
+    - |
+      if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+      else
+        pip install tinybird-cli
+      fi
 
     # Tinybird version
     - tb --version
@@ -117,7 +122,12 @@ variables:
     - source .venv/bin/activate
 
     # Install Tinybird CLI
-    - pip install tinybird-cli
+    - |
+      if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+      else
+        pip install tinybird-cli
+      fi
 
     # Tinybird version
     - tb --version
@@ -183,7 +193,12 @@ variables:
     - source .venv/bin/activate
 
     # Install Tinybird CLI
-    - pip install tinybird-cli
+    - |
+      if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+      else
+        pip install tinybird-cli
+      fi
 
     # Tinybird version
     - tb --version
@@ -209,7 +224,12 @@ variables:
     - source .venv/bin/activate
 
     # Install Tinybird CLI
-    - pip install tinybird-cli
+    - |
+      if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+      else
+        pip install tinybird-cli
+      fi
 
     # Tinybird version
     - tb --version
@@ -233,7 +253,12 @@ variables:
     - source .venv/bin/activate
 
     # Install Tinybird CLI
-    - pip install tinybird-cli
+    - |
+      if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+      else
+        pip install tinybird-cli
+      fi
 
     # Tinybird version
     - tb --version
@@ -258,7 +283,12 @@ variables:
     - source .venv/bin/activate
 
     # Install Tinybird CLI
-    - pip install tinybird-cli
+    - |
+      if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+      else
+        pip install tinybird-cli
+      fi
 
     # Tinybird version
     - tb --version
@@ -282,7 +312,12 @@ variables:
     - source .venv/bin/activate
 
     # Install Tinybird CLI
-    - pip install tinybird-cli
+    - |
+      if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+      else
+        pip install tinybird-cli
+      fi
 
     # Tinybird version
     - tb --version

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -130,7 +130,7 @@ variables:
       tb \
         --host $TB_HOST \
         --token $TB_ADMIN_TOKEN \
-        env create tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
+        env create tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
         ${_ENV_FLAGS}
 
     # List changes with Main Environment
@@ -219,7 +219,7 @@ variables:
       tb \
       --host $TB_HOST \
       --token $TB_ADMIN_TOKEN \
-      env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
+      env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
       --yes
 
 .release_promote:

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -46,12 +46,28 @@ variables:
     # Check auth
     tb --host $TB_HOST --token $TB_ADMIN_TOKEN auth info
 
+    # Try delete previous Environment
+    - |
+      output=$(tb env ls)
+      ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH}"
+
+      # Check if the environment name exists in the output
+      if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
+          tb \
+            --host ${{ vars.TB_HOST }} \
+            --token ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }} \
+            env rm $ENVIRONMENT_NAME \
+            --yes
+      else
+          echo "Skipping clean up: The Environment '$ENVIRONMENT_NAME' does not exist."
+      fi
+
     # Create new test Environment with data
     - |
       tb \
         --host $TB_HOST \
         --token $TB_ADMIN_TOKEN \
-        env create tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
+        env create tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
         ${_ENV_FLAGS}
 
     # List changes with Main Environment
@@ -114,7 +130,7 @@ variables:
       tb \
         --host $TB_HOST \
         --token $TB_ADMIN_TOKEN \
-        env create tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
+        env create tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
         ${_ENV_FLAGS}
 
     # List changes with Main Environment
@@ -177,7 +193,7 @@ variables:
       tb \
       --host $TB_HOST \
       --token $TB_ADMIN_TOKEN \
-      env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
+      env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
       --yes
 
 .cleanup_cd_branch:
@@ -203,7 +219,7 @@ variables:
       tb \
       --host $TB_HOST \
       --token $TB_ADMIN_TOKEN \
-      env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_SHORT_SHA} \
+      env rm tmp_cd_${_NORMALIZED_ENV_NAME}_${CI_COMMIT_BRANCH} \
       --yes
 
 .release_promote:

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -57,7 +57,7 @@ variables:
       ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_MERGE_REQUEST_IID}"
 
       # Check if the environment name exists in the output
-      if [[ $output == *"$ENVIRONMENT_NAME"* ]]; then
+      if echo "$output" | grep -q "\b$ENVIRONMENT_NAME\b"; then
           tb \
             --host $TB_HOST \
             --token $TB_ADMIN_TOKEN \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+Next release
+============
+
+- Support for a `requirements.txt` file inside the Data Project folder. That way you can control which version of the `tinybird-cli` to install.
+- Environments in CI are now created with a fixed name using the Pull Request number.
+- Environments are not cleaned up after CI finishes. This is a very convenient workflow to debug issues directly in the Environment with the changes of the branch deployed.
+- Users updating from previous versions need to do some actions:
+  - GitHub: Add the `closed` type like [this](https://github.com/tinybirdco/ci_analytics/pull/12/commits/01a207ab2dac38a18ea76c81b0b3087ad3f9cb91).
+  - GitLab: Change the rule to run the clean up job on merge:
+
+  ```yaml
+  - &cli_cleanup_rule
+    if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    changes:
+      - .gitlab-ci.yml
+      - ./**/*
+    when: always
+    ```
+- If you have doubts when updating just drop the .github or .gitlab-ci.yml workflow and re-run `tb init --git` using the latest version of `tinybird-cli` to re-generate the CI/CD templates.
+- `.tinyenv` now supports `export OBFUSCATE_REGEX_PATTERN=<regex>` to have a list of regex separated by `|` to obfuscate the output of regression tests. It requires version 1.0.1 of tinybird-cli.


### PR DESCRIPTION
Added some changes:

- If there's a requirements.txt in the data project it has precedence over `pip install tinybird-cli`, that way you have more control over the CLI version used.
- Environments are now created with the pull request number and they are only deleted on merge or closed PR. This has been only tested on GitHub workflows and requires update existing projects to add the `closed` event.
- `release_*` jobs are now run manually on GitHub.
- `source .tinyenv` before running regression tests so you can export env variables like `OBFUSCATE_REGEX_PATTERN`
- Adds all same changes for GitLab