### PR TITLE
Hide the warning informing about a new version when running the fixture tests

### DIFF
--- a/scripts/exec_test.sh
+++ b/scripts/exec_test.sh
@@ -5,7 +5,7 @@ fail=0;
 for t in `find ./tests -name "*.test"`; do
   echo "** Running $t **"
   echo "** $(cat $t)"
-  if res=$(bash $t $1 | diff -B ${t}.result -); then
+  if res=$(bash $t $1 --no-version-warning | diff -B ${t}.result -); then
     echo 'OK';
   else
     echo "failed, diff:";

--- a/scripts/exec_test.sh
+++ b/scripts/exec_test.sh
@@ -2,10 +2,13 @@
 
 fail=0;
 
+# We set this environment variable to avoid the CLI to show the warning about a new version
+export TB_VERSION_WARNING=0
+
 for t in `find ./tests -name "*.test"`; do
   echo "** Running $t **"
   echo "** $(cat $t)"
-  if res=$(bash $t $1 --no-version-warning | diff -B ${t}.result -); then
+  if res=$(bash $t $1 | diff -B ${t}.result -); then
     echo 'OK';
   else
     echo "failed, diff:";


### PR DESCRIPTION
Why default the CLI of Tinybird will show a warning when a new version appears like

```
** UPDATE AVAILABLE: please run "pip install tinybird-cli==1.0.1" to update
** current: tinybird-cli 1.0.0
```

This will cause problems in the fixture test as the diff will report a difference, but it's just the warning message. So, let's hide this warning