### PR TITLE
use author name to name environments

### DIFF
--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -54,7 +54,8 @@ variables:
     # Try delete previous Environment
     - |
       output=$(tb --host $TB_HOST --token $TB_ADMIN_TOKEN env ls)
-      ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_MERGE_REQUEST_IID}"
+      AUTHOR=$(echo "$CI_COMMIT_AUTHOR" | sed -E 's/[^a-zA-Z0-9]//g')
+      ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${AUTHOR}"
 
       # Check if the environment name exists in the output
       if echo "$output" | grep -q "\b$ENVIRONMENT_NAME\b"; then
@@ -72,7 +73,7 @@ variables:
       tb \
         --host $TB_HOST \
         --token $TB_ADMIN_TOKEN \
-        env create tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_MERGE_REQUEST_IID} \
+        env create ${ENVIRONMENT_NAME} \
         ${_ENV_FLAGS}
 
     # List changes with Main Environment
@@ -187,6 +188,8 @@ variables:
     - *validate_input
     - cd $CI_PROJECT_DIR/$DATA_PROJECT_DIR
     - _NORMALIZED_ENV_NAME=$(echo $DATA_PROJECT_DIR | rev | cut -d "/" -f 1 | rev | tr '.-' '_')
+    - AUTHOR=$(echo "$CI_COMMIT_AUTHOR" | sed -E 's/[^a-zA-Z0-9]//g')
+    - ENVIRONMENT_NAME="tmp_ci_${_NORMALIZED_ENV_NAME}_${AUTHOR}"
 
     # Create Python Virtual Environment
     - python -m venv .venv
@@ -208,7 +211,7 @@ variables:
       tb \
       --host $TB_HOST \
       --token $TB_ADMIN_TOKEN \
-      env rm tmp_ci_${_NORMALIZED_ENV_NAME}_${CI_MERGE_REQUEST_IID} \
+      env rm ${ENVIRONMENT_NAME} \
       --yes
 
 .cleanup_cd_branch:


### PR DESCRIPTION
Closes https://github.com/tinybirdco/ci/issues/22

- `CI_MERGE_REQUEST_IID` cannot be used as part of the Environment name, since it's only provided in MR creation, so wen merging / closing there's no reference to it.
- Using `CI_COMMIT_AUTHOR` which might be available at merge time.
- This requires the clean up rule to update to run when the MR is merged.
```
- &cli_telemetry_cleanup_rule
    if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
```
- I haven't found an easy way to run a pipeline in GitLab on MR close, so environments  won't be deleted when a MR is closed yet.

This has the problem an author can only have a single environment for all their PRs