### PR TITLE
Add permissions to execute the deploy script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,7 +83,8 @@ jobs:
         run: |
             CI_DEPLOY_FILE=./deploy/${VERSION}/ci-deploy.sh
             if [ -f "$CI_DEPLOY_FILE" ]; then
-              ./deploy/${VERSION}/ci-deploy.sh
+              chmod +x $CI_DEPLOY_FILE
+              $CI_DEPLOY_FILE
             else
               tb deploy --populate --fixtures --wait
             fi
@@ -110,7 +111,8 @@ jobs:
         run: |
             CD_DEPLOY_FILE=./deploy/${VERSION}/cd-deploy.sh
             if [ -f "$CD_DEPLOY_FILE" ]; then
-              ./deploy/${VERSION}/cd-deploy.sh
+              chmod +x $CD_DEPLOY_FILE
+              $CD_DEPLOY_FILE
             fi
 
   cleanup:

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -83,6 +83,7 @@ variables:
     - |
       CI_DEPLOY_FILE=./deploy/${VERSION}/ci-deploy.sh
       if [ -f "$CI_DEPLOY_FILE" ]; then
+        chmod +x deploy/${VERSION}/ci-deploy.sh
         ./deploy/${VERSION}/ci-deploy.sh
       else
         tb deploy --populate --fixtures --wait

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -83,8 +83,8 @@ variables:
     - |
       CI_DEPLOY_FILE=./deploy/${VERSION}/ci-deploy.sh
       if [ -f "$CI_DEPLOY_FILE" ]; then
-        chmod +x deploy/${VERSION}/ci-deploy.sh
-        ./deploy/${VERSION}/ci-deploy.sh
+        chmod +x $CI_DEPLOY_FILE
+        $CI_DEPLOY_FILE
       else
         tb deploy --populate --fixtures --wait
       fi
@@ -152,7 +152,8 @@ variables:
     - |
       CI_DEPLOY_FILE=./deploy/${VERSION}/ci-deploy.sh
       if [ -f "$CI_DEPLOY_FILE" ]; then
-        ./deploy/${VERSION}/ci-deploy.sh
+        chmod +x $CI_DEPLOY_FILE
+        $CI_DEPLOY_FILE
       else
         tb deploy --populate --fixtures --wait
       fi
@@ -179,7 +180,8 @@ variables:
     - |
       CD_DEPLOY_FILE=./deploy/${VERSION}/cd-deploy.sh
       if [ -f "$CD_DEPLOY_FILE" ]; then
-        ./deploy/${VERSION}/cd-deploy.sh
+        chmod +x $CD_DEPLOY_FILE
+        $CD_DEPLOY_FILE
       fi
 
 .cleanup_ci_branch:


### PR DESCRIPTION
To be able to execute the ci-deploy.sh script, it needs permissions.