### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Run data quality tests
         run: |
-          tb test run -v
+          tb test run -v -c 4
 
       - name: Get regression labels
         id: regression_labels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,6 @@ jobs:
           env create tmp_ci_${_NORMALIZED_ENV_NAME}_${{ github.event.pull_request.number }} \
           ${_ENV_FLAGS}
 
-      - name: List changes with Main Environment
-        run: tb diff --main --no-verbose
-
       - name: Deploy changes to the test Environment
         run: |
             source .tinyenv
@@ -123,9 +120,6 @@ jobs:
                 $CI_DEPLOY_FILE
               fi
             fi
-
-      - name: List changes with test Environment (should be empty)
-        run: tb diff
 
       - name: Run fixture tests
         run: |

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -108,7 +108,7 @@ variables:
       fi
 
     # Run data quality tests
-    - tb test run -v
+    - tb test run -v -c 4
 
     # Run pipe regression tests
     - echo ${CI_MERGE_REQUEST_LABELS}

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -76,9 +76,6 @@ variables:
         env create ${ENVIRONMENT_NAME} \
         ${_ENV_FLAGS}
 
-    # List changes with Main Environment
-    - tb diff --main --no-verbose
-
     # Deploy changes to the test Environment
     - |
       CI_DEPLOY_FILE=./deploy/${VERSION}/ci-deploy.sh
@@ -104,9 +101,6 @@ variables:
           $CI_DEPLOY_FILE
         fi
       fi
-
-    # List changes with test Environment (should be empty)
-    - tb diff
 
     - |
       if [ -f ./scripts/exec_test.sh ]; then


### PR DESCRIPTION
Save some time:
* Removing `tb diff` steps: not very useful when relying on git and tb deploy output
* Allow run tb run test with concurrency `-c/--concurrency`