### PR TITLE
Add check to version 0.0.0 to avoid default deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Deploy changes to the main Workspace
         run: |
             DEPLOY_FILE=./deploy/${VERSION}/deploy.sh
-            if [ ! -f "$DEPLOY_FILE" ]; then
+            if [ ! -f "$DEPLOY_FILE" ] && [ "$VERSION" != "0.0.0" ]; then
               echo "$DEPLOY_FILE not found, running default tb deploy command"
               tb --semver ${VERSION} deploy ${CD_FLAGS}
               tb release ls

--- a/.gitlab/ci_cd.yaml
+++ b/.gitlab/ci_cd.yaml
@@ -224,7 +224,7 @@ variables:
     # Deploy changes to the main Workspace
     - |
       DEPLOY_FILE=./deploy/${VERSION}/deploy.sh
-      if [ ! -f "$DEPLOY_FILE" ]; then
+      if [ ! -f "$DEPLOY_FILE" ] && [ "$VERSION" != "0.0.0" ]; then
         echo "$DEPLOY_FILE not found, running default tb deploy command"
         tb --semver ${VERSION} deploy ${CD_FLAGS}
         tb release ls


### PR DESCRIPTION
## Description

When doing the first automatic sync, we don't need to deploy the first release since the release should be already present