### PR TITLE
Parametrize git depth

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ on:
         default: .
       git_depth:
         description: "Number of commits to fetch. 0 indicates all history for all branches and tags"
+        required: false
         type: number
         default: 300
     secrets:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: .
+      git_depth:
+        description: "Number of commits to fetch. 0 indicates all history for all branches and tags"
+        type: number
+        default: 300
     secrets:
       tb_admin_token:
         required: true
@@ -25,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 300
+          fetch-depth: ${{ inputs.git_depth }}
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
         default: false
       git_depth:
         description: "Number of commits to fetch. 0 indicates all history for all branches and tags"
+        required: false
         type: number
         default: 300
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: boolean
         default: false
+      git_depth:
+        description: "Number of commits to fetch. 0 indicates all history for all branches and tags"
+        type: number
+        default: 300
     secrets:
       tb_admin_token:
         required: true
@@ -64,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          fetch-depth: 300
+          fetch-depth: ${{ inputs.git_depth }}
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:
@@ -166,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          fetch-depth: 300
+          fetch-depth: ${{ inputs.data_project_dir }}
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v3.1.1 (Next release)
 =====================
 
 - Feedback improved when adding Pull Request labels in the `tb branch regression-tests` command if there is a `regression.yaml` config file defined
+- Added `git_depth` on GitHub `cd.yml` and `ci.yml` in order to parametrize git checkout depth [MR](https://github.com/tinybirdco/ci/pull/71)
 
 
 v3.1.0


### PR DESCRIPTION
By default we defined arbitrary 300 depth to fetch from git.

Now when needing custom number:

- GitHub: pass in `with` clause new input `git_depth: <desired_value>`
- GitLab: add variable `GIT_DEPTH: <desired_value>`  when extending `tb_deploy_ci` and `tb_deploy_main`
