### PR TITLE
fix: error handling for missing fixtures

### DIFF
--- a/scripts/append_fixtures.sh
+++ b/scripts/append_fixtures.sh
@@ -11,12 +11,16 @@ absolute_directory=$(realpath "$directory")
 for extension in "${extensions[@]}"; do
   file_list=$(find "$absolute_directory" -type f -name "*.$extension")
 
-  for file_path in $file_list; do
-    file_name=$(basename "$file_path")
-    file_name_without_extension="${file_name%.*}"
+  if [ -z "$file_list" ]; then
+    echo "⚠️ Warning: No files with .$extension extension found in $absolute_directory"
+  else
+    for file_path in $file_list; do
+      file_name=$(basename "$file_path")
+      file_name_without_extension="${file_name%.*}"
 
-    command="tb --semver $VERSION datasource append $file_name_without_extension datasources/fixtures/$file_name"
-    echo $command
-    $command
-  done
+      command="tb --semver $VERSION datasource append $file_name_without_extension datasources/fixtures/$file_name"
+      echo $command
+      $command
+    done
+  fi
 done


### PR DESCRIPTION
Ensure that the `'append fixture' `step in the CI workflow can execute successfully, even if the datasources/fixtures directory is empty.


![append_fixtures_error](https://github.com/tinybirdco/ci/assets/14616032/168bd227-34b0-4c44-8e54-b70f5bc6567f)
