### PR TITLE
Added retries in the exec test script

### DIFF
--- a/scripts/exec_test.sh
+++ b/scripts/exec_test.sh
@@ -3,6 +3,7 @@ set -e
 
 export TB_VERSION_WARNING=0
 export VERSION=$1
+TOTAL_RETRIES=5
 
 run_test() {
     t=$1
@@ -13,23 +14,42 @@ run_test() {
     fi
     echo "** $(cat $t)"
     tmpfile=$(mktemp)
-    if bash $t $2 >$tmpfile; then
-        if diff -B ${t}.result $tmpfile; then
-            echo "Test $t: OK";
+    retries=0
+
+    # When appending fixtures, we need to retry in case of the data is not replicated in time
+    while [ $retries -lt $TOTAL_RETRIES ]; do
+        # Run the test and store the output in a temporary file
+        if bash $t $2 >$tmpfile; then
+            # If the test passed, break the loop
+            if diff -B ${t}.result $tmpfile; then
+                break
+            # If the test failed, increment the retries counter and try again
+            else
+                retries=$((retries+1))
+            fi
+        # If the bash command failed, print an error message and break the loop
         else
-            echo "🚨 ERROR: Test $t failed, diff:";
-            diff -B ${t}.result $tmpfile
-            cat $tmpfile
-            rm $tmpfile
-            return 1
+            break
         fi
+    done
+
+    if diff -B ${t}.result $tmpfile; then
+        echo "✅ Test $t passed"
+        rm $tmpfile
+        return 0
+    elif [ $retries -eq $TOTAL_RETRIES ]; then
+        echo "🚨 ERROR: Test $t failed, diff:";
+        diff -B ${t}.result $tmpfile
+        cat $tmpfile
+    
+        rm $tmpfile
+        return 1
     else
         echo "🚨 ERROR: Test $t failed with bash command exit code $?"
         cat $tmpfile
         rm $tmpfile
         return 1
     fi
-    rm $tmpfile
     echo ""
 }
 export -f run_test

--- a/scripts/exec_test.sh
+++ b/scripts/exec_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euxo pipefail
 
 export TB_VERSION_WARNING=0
 export VERSION=$1


### PR DESCRIPTION
## Description

When running tests with fixtures, the data might not yet be replicated to all the replicas and might case the test to fail. So we need to do some retries